### PR TITLE
implement redis-caching for searches(search-service)

### DIFF
--- a/search-service/src/controllers/searchController.js
+++ b/search-service/src/controllers/searchController.js
@@ -2,8 +2,14 @@ import { Search } from "../models/Search.js";
 
 const searcPostController = async (req, res) => {
   try {
-    const { query } = req.query;
+    const cacheKey = `search:${req.url}`;
+    const cacheSearch = await req.redisClient.get(cacheKey);
+    console.log(cacheKey);
 
+    if (cacheSearch) {
+      return res.json(JSON.parse(cacheSearch));
+    }
+    const { query } = req.query;
     const results = await Search.find(
       {
         $text: { $search: query },
@@ -14,8 +20,15 @@ const searcPostController = async (req, res) => {
     )
       .sort({ score: { $meta: "textScore" } })
       .limit(10);
+    if (!results) {
+      return res
+        .status(200)
+        .json({ success: false, message: "Query not found" });
+    }
+    await req.redisClient.setex(cacheKey, 300, JSON.stringify(results));
+    // console.log(results, `cachedSearch:${cacheKey}`);
 
-    return res.json(results);
+    res.json(results);
   } catch (error) {
     console.log(error);
   }

--- a/search-service/src/server.js
+++ b/search-service/src/server.js
@@ -30,7 +30,14 @@ app.use(helmet());
 app.use(cors());
 app.use(express.json());
 
-app.use("/api/search", searchRoutes);
+app.use(
+  "/api/search",
+  (req, res, next) => {
+    req.redisClient = redisClient;
+    next();
+  },
+  searchRoutes
+);
 
 app.use(errorHandler);
 


### PR DESCRIPTION
## Summary by Sourcery

Implement Redis caching for the search endpoint by injecting the Redis client into request handling, returning cached results on hits, querying and caching results on misses, and handling empty queries gracefully

New Features:
- Cache search results in Redis with a 5-minute expiry

Bug Fixes:
- Return a 200 status with a failure message when a search yields no results

Enhancements:
- Attach the Redis client to search routes via middleware
- Check for cached responses before querying the database and store results after queries